### PR TITLE
Add detection of conditional jumps as markers

### DIFF
--- a/python_src/program_markers/markers.py
+++ b/python_src/program_markers/markers.py
@@ -292,8 +292,12 @@ class FunctionCallStrategy(MarkerStrategy):
 
     @staticmethod
     def marker_detection_regex() -> re.Pattern[str]:
-        # (call|j[a-z]{1,2}) checks that the instruction either starts with call or j and two letters (thus, including conditional and uncoditional jumps)
-        return re.compile(f".*(call|j[a-z]{{1,2}}).*({'|'.join(marker_prefixes())})([0-9]+)_.*")
+        # (call|j[a-z]{1,2}) checks that the instruction either starts with
+        # call or j and two letters (thus, including conditional
+        # and uncoditional jumps)
+        return re.compile(
+            f".*(call|j[a-z]{{1,2}}).*({'|'.join(marker_prefixes())})([0-9]+)_.*"
+        )
 
     @staticmethod
     def regex_marker_id_group_index() -> int:

--- a/python_src/program_markers/markers.py
+++ b/python_src/program_markers/markers.py
@@ -292,7 +292,8 @@ class FunctionCallStrategy(MarkerStrategy):
 
     @staticmethod
     def marker_detection_regex() -> re.Pattern[str]:
-        return re.compile(f".*(call|jmp).*({'|'.join(marker_prefixes())})([0-9]+)_.*")
+        # (call|j[a-z]{1,2}) checks that the instruction either starts with call or j and two letters (thus, including conditional and uncoditional jumps)
+        return re.compile(f".*(call|j[a-z]{{1,2}}).*({'|'.join(marker_prefixes())})([0-9]+)_.*")
 
     @staticmethod
     def regex_marker_id_group_index() -> int:


### PR DESCRIPTION
This PR includes support for detecting conditional jumps as markers. Thus, if the compiler creates a conditional jump to the marker, program-markers will now be able to detect the marker, too.